### PR TITLE
カメラの時間制限

### DIFF
--- a/Modules/DeviceTimer.cs
+++ b/Modules/DeviceTimer.cs
@@ -8,7 +8,11 @@ namespace TownOfHost.Modules
 {
     public static class DeviceTimer
     {
-        public static bool CamerasRanOut => camerasRanOut && isEnabled;
+        public static bool CamerasRanOut
+        {
+            get => camerasRanOut && isEnabled;
+            private set => camerasRanOut = value;
+        }
         private static bool camerasRanOut;
         private static int numPlayersWatchingCamera;
         private static bool isEnabled;
@@ -18,7 +22,7 @@ namespace TownOfHost.Modules
 
         public static void Init()
         {
-            camerasRanOut = false;
+            CamerasRanOut = false;
             numPlayersWatchingCamera = 0;
             isEnabled = Options.CamerasTimer.GetBool();
             camerasRemaining = Options.CamerasMaxTimer.GetInt();
@@ -97,7 +101,7 @@ namespace TownOfHost.Modules
             if (time <= 0f)
             {
                 Logger.Info($"Destroy: {System.DateTime.Now:HH:mm:ss}", nameof(DeviceTimer));
-                camerasRanOut = true;
+                CamerasRanOut = true;
             }
         }
         public static void UpdateNotifyText()
@@ -109,7 +113,7 @@ namespace TownOfHost.Modules
             var notifyBuilder = new StringBuilder();
 
             notifyBuilder.Append("カメラ: ");
-            if (camerasRanOut)
+            if (CamerasRanOut)
             {
                 notifyBuilder.AppendLine("時間切れ");
             }
@@ -154,7 +158,7 @@ namespace TownOfHost.Modules
             {
                 return string.Empty;
             }
-            if (!camerasRanOut)
+            if (!CamerasRanOut)
             {
                 return string.Empty;
             }
@@ -167,7 +171,7 @@ namespace TownOfHost.Modules
         }
         public static void UpdateUnusableNotify(PlayerControl player)
         {
-            if (!AmongUsClient.Instance.AmHost || !isEnabled || !camerasRanOut)
+            if (!AmongUsClient.Instance.AmHost || !isEnabled || !CamerasRanOut)
             {
                 return;
             }

--- a/Modules/DeviceTimer.cs
+++ b/Modules/DeviceTimer.cs
@@ -1,0 +1,195 @@
+using System.Collections.Generic;
+using System.Text;
+
+using Hazel;
+using UnityEngine;
+
+namespace TownOfHost.Modules
+{
+    public static class DeviceTimer
+    {
+        public static bool CamerasRanOut => camerasRanOut && isEnabled;
+        private static bool camerasRanOut;
+        private static int numPlayersWatchingCamera;
+        private static bool isEnabled;
+        private static float camerasRemaining;
+        private static string notifyText;
+        private static HashSet<byte> unusableNotifyTargets;
+
+        public static void Init()
+        {
+            camerasRanOut = false;
+            numPlayersWatchingCamera = 0;
+            isEnabled = Options.CamerasTimer.GetBool();
+            camerasRemaining = Options.CamerasMaxTimer.GetInt();
+            UpdateNotifyText();
+            unusableNotifyTargets = new();
+        }
+        public static void HandleRepairSystem(SystemTypes systemType, byte amount)
+        {
+            if (!AmongUsClient.Instance.AmHost || !isEnabled)
+            {
+                return;
+            }
+            if (systemType != SystemTypes.Security)
+            {
+                return;
+            }
+
+            switch (amount)
+            {
+                case 1: BeginCamera(); break;
+                case 2: CloseCamera(); break;
+            }
+        }
+        public static void BeginCamera()
+        {
+            if (!AmongUsClient.Instance.AmHost || !isEnabled)
+            {
+                return;
+            }
+            numPlayersWatchingCamera++;
+            Logger.Info($"Begin: {System.DateTime.Now:HH:mm:ss}", "DeviceTimer");
+        }
+        public static void CloseCamera()
+        {
+            if (!AmongUsClient.Instance.AmHost || !isEnabled)
+            {
+                return;
+            }
+            numPlayersWatchingCamera--;
+            Logger.Info($"Close: {System.DateTime.Now:HH:mm:ss}", "DeviceTimer");
+        }
+        public static void ConsumeCamera()
+        {
+            if (!AmongUsClient.Instance.AmHost || !isEnabled)
+            {
+                return;
+            }
+            camerasRemaining -= Time.fixedDeltaTime * numPlayersWatchingCamera;
+            if (camerasRemaining <= 0f && !CamerasRanOut)
+            {
+                RpcUpdateCamerasUsable(camerasRemaining);
+            }
+        }
+        public static void RpcUpdateCamerasUsable(float time)
+        {
+            if (AmongUsClient.Instance.AmHost)
+            {
+                Logger.Info("【RpcUpdateCamerasUsable】", nameof(DisableDevice));
+                var writer = AmongUsClient.Instance.StartRpcImmediately(
+                    PlayerControl.LocalPlayer.NetId,
+                    (byte)CustomRPC.UpdateCamerasUsable,
+                    SendOption.Reliable);
+                writer.Write(time);
+                AmongUsClient.Instance.FinishRpcImmediately(writer);
+            }
+
+            UpdateCamerasUsable(time);
+        }
+        public static void UpdateCamerasUsable(float time)
+        {
+            if (!isEnabled || CamerasRanOut)
+            {
+                return;
+            }
+
+            if (time <= 0f)
+            {
+                Logger.Info($"Destroy: {System.DateTime.Now:HH:mm:ss}", "DeviceTimer");
+                camerasRanOut = true;
+            }
+        }
+        public static void UpdateNotifyText()
+        {
+            if (!isEnabled)
+            {
+                return;
+            }
+            var notifyBuilder = new StringBuilder();
+
+            notifyBuilder.Append("カメラ: ");
+            if (camerasRanOut)
+            {
+                notifyBuilder.AppendLine("時間切れ");
+            }
+            else
+            {
+                notifyBuilder.AppendFormat("あと {0:0.00} 秒", camerasRemaining).AppendLine();
+            }
+
+            notifyText = notifyBuilder.ToString();
+        }
+        public static void SendNotifyText()
+        {
+            if (!isEnabled)
+            {
+                return;
+            }
+            Utils.SendMessage(notifyText, title: Utils.ColorString(Color.cyan, "デバイスの残り時間"));
+        }
+        private static bool IsNearCamera(PlayerControl player)
+        {
+            var usableDistance = DisableDevice.UsableDistance();
+            var playerPosition = player.GetTruePosition();
+            var devicePositions = DisableDevice.DevicePos;
+            var devicePosition = (MapNames)Main.NormalOptions.MapId switch
+            {
+                MapNames.Airship => devicePositions["AirshipCamera"],
+                MapNames.Polus => devicePositions["PolusCamera"],
+                MapNames.Skeld => devicePositions["SkeldCamera"],
+                _ => Vector2.zero
+            };
+            if (devicePosition == Vector2.zero)
+            {
+                return false;
+            }
+            var distance = Vector2.Distance(playerPosition, devicePosition);
+
+            return distance <= usableDistance;
+        }
+        public static string GetNameNotifyText(PlayerControl player)
+        {
+            if (player.IsModClient())
+            {
+                return string.Empty;
+            }
+            if (!camerasRanOut)
+            {
+                return string.Empty;
+            }
+
+            if (unusableNotifyTargets.Contains(player.PlayerId))
+            {
+                return Utils.ColorString(Color.cyan, "使用不可");
+            }
+            return string.Empty;
+        }
+        public static void UpdateUnusableNotify(PlayerControl player)
+        {
+            if (!AmongUsClient.Instance.AmHost || !isEnabled || !camerasRanOut)
+            {
+                return;
+            }
+            if (player.IsModClient())
+            {
+                return;
+            }
+
+            if (!IsNearCamera(player))
+            {
+                if (unusableNotifyTargets.Contains(player.PlayerId))
+                {
+                    unusableNotifyTargets.Remove(player.PlayerId);
+                    Utils.NotifyRoles(SpecifySeer: player);
+                }
+                return;
+            }
+
+            if (unusableNotifyTargets.Add(player.PlayerId))
+            {
+                Utils.NotifyRoles(SpecifySeer: player);
+            }
+        }
+    }
+}

--- a/Modules/DeviceTimer.cs
+++ b/Modules/DeviceTimer.cs
@@ -25,13 +25,13 @@ namespace TownOfHost.Modules
             UpdateNotifyText();
             unusableNotifyTargets = new();
         }
-        public static void HandleRepairSystem(SystemTypes systemType, byte amount)
+        public static void HandleRepairSystem(SystemTypes systemType, PlayerControl player, byte amount)
         {
             if (!AmongUsClient.Instance.AmHost || !isEnabled)
             {
                 return;
             }
-            if (systemType != SystemTypes.Security)
+            if (systemType != SystemTypes.Security || !player.IsAlive())
             {
                 return;
             }

--- a/Modules/DeviceTimer.cs
+++ b/Modules/DeviceTimer.cs
@@ -150,7 +150,7 @@ namespace TownOfHost.Modules
         }
         public static string GetNameNotifyText(PlayerControl player)
         {
-            if (player.IsModClient())
+            if (player.IsModClient() || !player.IsAlive())
             {
                 return string.Empty;
             }

--- a/Modules/DeviceTimer.cs
+++ b/Modules/DeviceTimer.cs
@@ -49,7 +49,7 @@ namespace TownOfHost.Modules
                 return;
             }
             numPlayersWatchingCamera++;
-            Logger.Info($"Begin: {System.DateTime.Now:HH:mm:ss}", "DeviceTimer");
+            Logger.Info($"Begin: {System.DateTime.Now:HH:mm:ss}", nameof(DeviceTimer));
         }
         public static void CloseCamera()
         {
@@ -58,7 +58,7 @@ namespace TownOfHost.Modules
                 return;
             }
             numPlayersWatchingCamera--;
-            Logger.Info($"Close: {System.DateTime.Now:HH:mm:ss}", "DeviceTimer");
+            Logger.Info($"Close: {System.DateTime.Now:HH:mm:ss}", nameof(DeviceTimer));
         }
         public static void ConsumeCamera()
         {
@@ -76,7 +76,7 @@ namespace TownOfHost.Modules
         {
             if (AmongUsClient.Instance.AmHost)
             {
-                Logger.Info("【RpcUpdateCamerasUsable】", nameof(DisableDevice));
+                Logger.Info("【RpcUpdateCamerasUsable】", nameof(DeviceTimer));
                 var writer = AmongUsClient.Instance.StartRpcImmediately(
                     PlayerControl.LocalPlayer.NetId,
                     (byte)CustomRPC.UpdateCamerasUsable,
@@ -96,7 +96,7 @@ namespace TownOfHost.Modules
 
             if (time <= 0f)
             {
-                Logger.Info($"Destroy: {System.DateTime.Now:HH:mm:ss}", "DeviceTimer");
+                Logger.Info($"Destroy: {System.DateTime.Now:HH:mm:ss}", nameof(DeviceTimer));
                 camerasRanOut = true;
             }
         }

--- a/Modules/DisableDevice.cs
+++ b/Modules/DisableDevice.cs
@@ -1,9 +1,10 @@
 using System;
 using System.Collections.Generic;
+
 using HarmonyLib;
-using Hazel;
-using InnerNet;
 using UnityEngine;
+
+using TownOfHost.Modules;
 
 namespace TownOfHost
 {
@@ -68,7 +69,7 @@ namespace TownOfHost
                             case 0:
                                 if (Options.DisableSkeldAdmin.GetBool())
                                     doComms |= Vector2.Distance(PlayerPos, DevicePos["SkeldAdmin"]) <= UsableDistance();
-                                if (Options.DisableSkeldCamera.GetBool())
+                                if (Options.DisableSkeldCamera.GetBool() || DeviceTimer.CamerasRanOut)
                                     doComms |= Vector2.Distance(PlayerPos, DevicePos["SkeldCamera"]) <= UsableDistance();
                                 break;
                             case 1:
@@ -83,7 +84,7 @@ namespace TownOfHost
                                     doComms |= Vector2.Distance(PlayerPos, DevicePos["PolusLeftAdmin"]) <= UsableDistance();
                                     doComms |= Vector2.Distance(PlayerPos, DevicePos["PolusRightAdmin"]) <= UsableDistance();
                                 }
-                                if (Options.DisablePolusCamera.GetBool())
+                                if (Options.DisablePolusCamera.GetBool() || DeviceTimer.CamerasRanOut)
                                     doComms |= Vector2.Distance(PlayerPos, DevicePos["PolusCamera"]) <= UsableDistance();
                                 if (Options.DisablePolusVital.GetBool())
                                     doComms |= Vector2.Distance(PlayerPos, DevicePos["PolusVital"]) <= UsableDistance();
@@ -93,7 +94,7 @@ namespace TownOfHost
                                     doComms |= Vector2.Distance(PlayerPos, DevicePos["AirshipCockpitAdmin"]) <= UsableDistance();
                                 if (Options.DisableAirshipRecordsAdmin.GetBool())
                                     doComms |= Vector2.Distance(PlayerPos, DevicePos["AirshipRecordsAdmin"]) <= UsableDistance();
-                                if (Options.DisableAirshipCamera.GetBool())
+                                if (Options.DisableAirshipCamera.GetBool() || DeviceTimer.CamerasRanOut)
                                     doComms |= Vector2.Distance(PlayerPos, DevicePos["AirshipCamera"]) <= UsableDistance();
                                 if (Options.DisableAirshipVital.GetBool())
                                     doComms |= Vector2.Distance(PlayerPos, DevicePos["AirshipVital"]) <= UsableDistance();

--- a/Modules/OptionHolder.cs
+++ b/Modules/OptionHolder.cs
@@ -544,7 +544,7 @@ namespace TownOfHost
             CamerasMaxTimer = IntegerOptionItem.Create(
                 101281,
                 "CamerasMaxTimer",
-                new(1, 99, 1), 10,
+                new(1, 120, 1), 10,
                 TabGroup.MainSettings,
                 false).SetParent(CamerasTimer).SetGameMode(CustomGameMode.Standard);
             DisableSkeldDevices = BooleanOptionItem.Create(101210, "DisableSkeldDevices", false, TabGroup.MainSettings, false).SetParent(DisableDevices)

--- a/Modules/OptionHolder.cs
+++ b/Modules/OptionHolder.cs
@@ -546,7 +546,7 @@ namespace TownOfHost
                 "CamerasMaxTimer",
                 new(1, 120, 1), 10,
                 TabGroup.MainSettings,
-                false).SetParent(CamerasTimer).SetGameMode(CustomGameMode.Standard);
+                false).SetParent(CamerasTimer).SetGameMode(CustomGameMode.Standard).SetValueFormat(OptionFormat.Seconds);
             DisableSkeldDevices = BooleanOptionItem.Create(101210, "DisableSkeldDevices", false, TabGroup.MainSettings, false).SetParent(DisableDevices)
                 .SetGameMode(CustomGameMode.Standard);
             DisableSkeldAdmin = BooleanOptionItem.Create(101211, "DisableSkeldAdmin", false, TabGroup.MainSettings, false).SetParent(DisableSkeldDevices)

--- a/Modules/OptionHolder.cs
+++ b/Modules/OptionHolder.cs
@@ -135,6 +135,8 @@ namespace TownOfHost
 
         //デバイスブロック
         public static OptionItem DisableDevices;
+        public static OptionItem CamerasTimer;
+        public static OptionItem CamerasMaxTimer;
         public static OptionItem DisableSkeldDevices;
         public static OptionItem DisableSkeldAdmin;
         public static OptionItem DisableSkeldCamera;
@@ -533,6 +535,18 @@ namespace TownOfHost
             DisableDevices = BooleanOptionItem.Create(101200, "DisableDevices", true, TabGroup.MainSettings, false)
                 .SetHeader(true)
                 .SetGameMode(CustomGameMode.Standard);
+            CamerasTimer = BooleanOptionItem.Create(
+                101280,
+                "CamerasTimer",
+                false,
+                TabGroup.MainSettings,
+                false).SetParent(DisableDevices).SetGameMode(CustomGameMode.Standard);
+            CamerasMaxTimer = IntegerOptionItem.Create(
+                101281,
+                "CamerasMaxTimer",
+                new(1, 99, 1), 10,
+                TabGroup.MainSettings,
+                false).SetParent(CamerasTimer).SetGameMode(CustomGameMode.Standard);
             DisableSkeldDevices = BooleanOptionItem.Create(101210, "DisableSkeldDevices", false, TabGroup.MainSettings, false).SetParent(DisableDevices)
                 .SetGameMode(CustomGameMode.Standard);
             DisableSkeldAdmin = BooleanOptionItem.Create(101211, "DisableSkeldAdmin", false, TabGroup.MainSettings, false).SetParent(DisableSkeldDevices)

--- a/Modules/RPC.cs
+++ b/Modules/RPC.cs
@@ -5,6 +5,7 @@ using AmongUs.GameOptions;
 using HarmonyLib;
 using Hazel;
 
+using TownOfHost.Modules;
 using TownOfHost.Roles.Impostor;
 using TownOfHost.Roles.Crewmate;
 using TownOfHost.Roles.Neutral;
@@ -38,6 +39,7 @@ namespace TownOfHost
         SetEvilTrackerTarget,
         SetRealKiller,
         SyncEvilHackerScenes,
+        UpdateCamerasUsable,
     }
     public enum Sounds
     {
@@ -193,6 +195,9 @@ namespace TownOfHost
                     break;
                 case CustomRPC.SyncEvilHackerScenes:
                     EvilHacker.ReceiveRPC(reader);
+                    break;
+                case CustomRPC.UpdateCamerasUsable:
+                    DeviceTimer.UpdateCamerasUsable(reader.ReadSingle());
                     break;
             }
         }

--- a/Modules/Utils.cs
+++ b/Modules/Utils.cs
@@ -764,6 +764,12 @@ namespace TownOfHost
                 if (seer.Is(CustomRoles.EvilHacker) && !isMeeting)
                     SelfSuffix.Append(EvilHacker.GetMurderSceneText(seer));
 
+                var deviceUnusableNotify = DeviceTimer.GetNameNotifyText(seer);
+                if (deviceUnusableNotify != string.Empty)
+                {
+                    SelfSuffix.Append(deviceUnusableNotify);
+                }
+
                 //RealNameを取得 なければ現在の名前をRealNamesに書き込む
                 string SeerRealName = seer.GetRealName(isMeeting);
 

--- a/Patches/CameraPatch.cs
+++ b/Patches/CameraPatch.cs
@@ -1,0 +1,89 @@
+using HarmonyLib;
+using TMPro;
+using UnityEngine;
+
+using TownOfHost.Modules;
+
+namespace TownOfHost.Patches
+{
+    [HarmonyPatch]
+    public static class CameraPatch
+    {
+        // バニラプレイヤーはコミュサボになるため，閉じるのではなくコミュサボ状態にする
+        private static bool ShouldScramble() => DeviceTimer.CamerasRanOut && PlayerControl.LocalPlayer.IsAlive();
+
+        [HarmonyPatch]
+        public static class PlanetSurveillanceMinigamePatch
+        {
+            private static TextMeshPro runOutText;
+
+            [HarmonyPatch(typeof(PlanetSurveillanceMinigame), nameof(PlanetSurveillanceMinigame.Update)), HarmonyPrefix]
+            public static bool UpdatePrefix(PlanetSurveillanceMinigame __instance)
+            {
+                if (ShouldScramble())
+                {
+                    __instance.isStatic = true;
+                    __instance.ViewPort.sharedMaterial = __instance.StaticMaterial;
+                    if (runOutText == null)
+                    {
+                        var sabText = __instance.SabText;
+                        sabText.gameObject.SetActive(false);
+                        runOutText = Object.Instantiate(sabText, sabText.transform.parent);
+                        runOutText.text = "時間切れ";
+                        runOutText.gameObject.SetActive(true);
+                    }
+
+                    return false;
+                }
+                return true;
+            }
+            [HarmonyPatch(typeof(PlanetSurveillanceMinigame), nameof(PlanetSurveillanceMinigame.NextCamera)), HarmonyPrefix]
+            public static bool NextCameraPrefix(PlanetSurveillanceMinigame __instance)
+            {
+                if (ShouldScramble())
+                {
+                    if (Constants.ShouldPlaySfx())
+                    {
+                        SoundManager.Instance.PlaySound(__instance.CloseSound, false);
+                    }
+                    return false;
+                }
+                return true;
+            }
+        }
+
+        [HarmonyPatch]
+        public static class SurveillanceMinigamePatch
+        {
+            private static TextMeshPro[] runOutTexts;
+
+            [HarmonyPatch(typeof(SurveillanceMinigame), nameof(SurveillanceMinigame.Update)), HarmonyPrefix]
+            public static bool UpdatePrefix(SurveillanceMinigame __instance)
+            {
+                if (ShouldScramble())
+                {
+                    if (runOutTexts == null)
+                    {
+                        runOutTexts = new TextMeshPro[__instance.ViewPorts.Length];
+                    }
+                    __instance.isStatic = true;
+                    for (int j = 0; j < __instance.ViewPorts.Length; j++)
+                    {
+                        __instance.ViewPorts[j].sharedMaterial = __instance.StaticMaterial;
+                        if (runOutTexts[j] == null)
+                        {
+                            var sabText = __instance.SabText[j];
+                            sabText.gameObject.SetActive(false);
+                            runOutTexts[j] = Object.Instantiate(sabText, sabText.transform.parent);
+                            runOutTexts[j].text = "時間切れ";
+                            runOutTexts[j].gameObject.SetActive(true);
+                        }
+                    }
+
+                    return false;
+                }
+                return true;
+            }
+        }
+    }
+}

--- a/Patches/ExilePatch.cs
+++ b/Patches/ExilePatch.cs
@@ -2,6 +2,7 @@ using System.Linq;
 using AmongUs.Data;
 using HarmonyLib;
 
+using TownOfHost.Modules;
 using TownOfHost.Roles.Impostor;
 using TownOfHost.Roles.Neutral;
 
@@ -167,6 +168,7 @@ namespace TownOfHost
 
             GameStates.AlreadyDied |= !Utils.IsAllAlive;
             RemoveDisableDevicesPatch.UpdateDisableDevices();
+            DeviceTimer.UpdateNotifyText();
             SoundManager.Instance.ChangeAmbienceVolume(DataManager.Settings.Audio.AmbienceVolume);
             Logger.Info("タスクフェイズ開始", "Phase");
         }

--- a/Patches/MeetingHudPatch.cs
+++ b/Patches/MeetingHudPatch.cs
@@ -2,9 +2,11 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
+
 using HarmonyLib;
 using UnityEngine;
 
+using TownOfHost.Modules;
 using TownOfHost.Roles.Impostor;
 using TownOfHost.Roles.Crewmate;
 using TownOfHost.Roles.Neutral;
@@ -330,6 +332,7 @@ namespace TownOfHost
             }
             if (MeetingStates.FirstMeeting) TemplateManager.SendTemplate("OnFirstMeeting", noErr: true);
             TemplateManager.SendTemplate("OnMeeting", noErr: true);
+            DeviceTimer.SendNotifyText();
 
             if (AmongUsClient.Instance.AmHost)
             {

--- a/Patches/PlayerContorolPatch.cs
+++ b/Patches/PlayerContorolPatch.cs
@@ -635,6 +635,11 @@ namespace TownOfHost
                 if (GameStates.IsInTask && player == PlayerControl.LocalPlayer)
                     DisableDevice.FixedUpdate();
 
+                if (GameStates.IsInTask)
+                {
+                    DeviceTimer.UpdateUnusableNotify(__instance);
+                }
+
                 if (GameStates.IsInGame && Main.RefixCooldownDelay <= 0)
                     foreach (var pc in Main.AllPlayerControls)
                     {

--- a/Patches/ShipStatusPatch.cs
+++ b/Patches/ShipStatusPatch.cs
@@ -1,9 +1,11 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+
 using HarmonyLib;
 using UnityEngine;
 
+using TownOfHost.Modules;
 using TownOfHost.Roles.Crewmate;
 using TownOfHost.Roles.Neutral;
 
@@ -17,6 +19,9 @@ namespace TownOfHost
             //ここより上、全員が実行する
             if (!AmongUsClient.Instance.AmHost) return;
             //ここより下、ホストのみが実行する
+
+            DeviceTimer.ConsumeCamera();
+
             if (Main.IsFixedCooldown && Main.RefixCooldownDelay >= 0)
             {
                 Main.RefixCooldownDelay -= Time.fixedDeltaTime;
@@ -89,9 +94,13 @@ namespace TownOfHost
             }
             return true;
         }
-        public static void Postfix(ShipStatus __instance)
+        public static void Postfix(
+            ShipStatus __instance,
+            [HarmonyArgument(0)] SystemTypes systemType,
+            [HarmonyArgument(2)] byte amount)
         {
             Camouflage.CheckCamouflage();
+            DeviceTimer.HandleRepairSystem(systemType, amount);
         }
         public static void CheckAndOpenDoorsRange(ShipStatus __instance, int amount, int min, int max)
         {

--- a/Patches/ShipStatusPatch.cs
+++ b/Patches/ShipStatusPatch.cs
@@ -97,10 +97,11 @@ namespace TownOfHost
         public static void Postfix(
             ShipStatus __instance,
             [HarmonyArgument(0)] SystemTypes systemType,
+            [HarmonyArgument(1)] PlayerControl player,
             [HarmonyArgument(2)] byte amount)
         {
             Camouflage.CheckCamouflage();
-            DeviceTimer.HandleRepairSystem(systemType, amount);
+            DeviceTimer.HandleRepairSystem(systemType, player, amount);
         }
         public static void CheckAndOpenDoorsRange(ShipStatus __instance, int amount, int min, int max)
         {

--- a/Patches/UsablesPatch.cs
+++ b/Patches/UsablesPatch.cs
@@ -123,12 +123,17 @@ namespace TownOfHost
         }
         private static bool IsUnusable(SystemConsole systemConsole)
         {
+            var player = PlayerControl.LocalPlayer;
+
             //   task_cams: Airship
             //  Surv_Panel: Polus
             // SurvConsole: Skeld
-            if (DeviceTimer.CamerasRanOut && systemConsole.name is "task_cams" or "Surv_Panel" or "SurvConsole")
+            if (player.IsAlive())
             {
-                return true;
+                if (DeviceTimer.CamerasRanOut && systemConsole.name is "task_cams" or "Surv_Panel" or "SurvConsole")
+                {
+                    return true;
+                }
             }
             return false;
         }

--- a/Patches/onGameStartedPatch.cs
+++ b/Patches/onGameStartedPatch.cs
@@ -141,6 +141,7 @@ namespace TownOfHost
             Workhorse.Init();
             CustomWinnerHolder.Reset();
             AntiBlackout.Reset();
+            DeviceTimer.Init();
             IRandom.SetInstanceById(Options.RoleAssigningAlgorithm.GetValue());
 
             MeetingStates.MeetingCalled = false;

--- a/Resources/string.csv
+++ b/Resources/string.csv
@@ -284,6 +284,8 @@
 "TieMode.All","Eject All","全員追放","全体放逐","全員放逐","Изгнать всех","Exilar Todos"
 "TieMode.Random","Eject Random","ランダムに追放","随机放逐","隨機放逐","Изгнать случайно","Exilar Aleatório"
 "DisableDevices","Disable Devices","デバイスを無効化","禁用设备","禁用裝置","Отключить устройства","Desativar Dispositivos"
+"CamerasTimer","Cameras Timer","カメラの時間制限(全マップ)","","","",""
+"CamerasMaxTimer","Cameras Max Timer","使用可能時間","","","",""
 "DisableSkeldDevices","Disable Skeld Devices","スケルドのデバイス無効化","禁用骷髅舰设备","禁用The Skeld中的設備","Отключить устройства на TheSkeld","Desativar Dispositivos de Skeld"
 "DisableMiraHQDevices","Disable MiraHQ Device","ミラHQのデバイス無効化","禁用米拉总部设备","禁用Mira HQ中的設備","Отключить устройства на MiraHQ","Desativar Dispositivos de MiraHQ"
 "DisablePolusDevices","Disable Polus Device","ポーラスのデバイス無効化","禁用波鲁斯设备","禁用Polus中的設備","Отключить устройства на Polus","Desativar Dispositivos de Polus"


### PR DESCRIPTION
カメラの時間制限オプションを追加
複数人が同時に見ると人数分消費される
秒数の更新は追放画面の終了時に行われる
会議開始時に全員に向けて残り時間がチャットで送信される
使い切るとバニラ視点Mod視点共にコミュサボ状態になる(バニラ視点はDisableDevicesの流用による Mod視点は挙動の差を埋めるため見かけのみカメラ画面をコミュサボ状態にする)
Mod視点は以後カメラが開けなくなる
Mod視点では使用ボタンの非活性化により前を通っただけで壊れていることがわかるので，使用可能圏内のバニラ視点では名前の3行目で`使用不可`と通知される
