### PR TITLE
会議と同時にベントに入ると判定が消えない問題修正

### DIFF
--- a/Modules/Utils.cs
+++ b/Modules/Utils.cs
@@ -936,6 +936,13 @@ namespace TownOfHost
             if (Options.AirShipVariableElectrical.GetBool())
                 AirShipElectricalDoors.Initialize();
             DoorsReset.ResetDoors();
+            // 空デデンバグ対応 会議後にベントを空にする
+            var ventilationSystem = ShipStatus.Instance.Systems.TryGetValue(SystemTypes.Ventilation, out var systemType) ? systemType.TryCast<VentilationSystem>() : null;
+            if (ventilationSystem != null)
+            {
+                ventilationSystem.PlayersInsideVents.Clear();
+                ventilationSystem.IsDirty = true;
+            }
         }
 
         public static void ChangeInt(ref int ChangeTo, int input, int max)

--- a/Patches/ShipStatusPatch.cs
+++ b/Patches/ShipStatusPatch.cs
@@ -189,20 +189,6 @@ namespace TownOfHost
             MeetingStates.ReportTarget = target;
             MeetingStates.DeadBodies = UnityEngine.Object.FindObjectsOfType<DeadBody>();
         }
-        public static void Postfix(ShipStatus __instance)
-        {
-            if (!AmongUsClient.Instance.AmHost)
-            {
-                return;
-            }
-            // 空デデンバグ対応 会議開始時にベントを空にする
-            var ventilationSystem = __instance.Systems.TryGetValue(SystemTypes.Ventilation, out var systemType) ? systemType.TryCast<VentilationSystem>() : null;
-            if (ventilationSystem != null)
-            {
-                ventilationSystem.PlayersInsideVents.Clear();
-                ventilationSystem.IsDirty = true;
-            }
-        }
     }
     [HarmonyPatch(typeof(ShipStatus), nameof(ShipStatus.Begin))]
     class BeginPatch


### PR DESCRIPTION
判定を消すタイミングを会議前から会議後に変更