### PR TITLE
オンラインでランダムスポーンが不安定な問題を修正

### DIFF
--- a/Modules/ExtendedPlayerControl.cs
+++ b/Modules/ExtendedPlayerControl.cs
@@ -574,9 +574,18 @@ namespace TownOfHost
             }
             return null;
         }
-        public static void RpcSnapTo(this PlayerControl pc, Vector2 position)
+        public static void RpcSnapToForced(this PlayerControl pc, Vector2 position)
         {
-            pc.NetTransform.RpcSnapTo(position);
+            var netTransform = pc.NetTransform;
+            if (AmongUsClient.Instance.AmClient)
+            {
+                netTransform.SnapTo(position, (ushort)(netTransform.lastSequenceId + 128));
+            }
+            ushort newSid = (ushort)(netTransform.lastSequenceId + 2);
+            MessageWriter messageWriter = AmongUsClient.Instance.StartRpcImmediately(netTransform.NetId, (byte)RpcCalls.SnapTo, SendOption.Reliable);
+            NetHelpers.WriteVector2(position, messageWriter);
+            messageWriter.Write(newSid);
+            AmongUsClient.Instance.FinishRpcImmediately(messageWriter);
         }
         public static void RpcSnapToDesync(this PlayerControl pc, PlayerControl target, Vector2 position)
         {

--- a/Patches/RandomSpawnPatch.cs
+++ b/Patches/RandomSpawnPatch.cs
@@ -290,7 +290,7 @@ namespace TownOfHost
             {
                 var location = GetLocation(!isRadndom);
                 Logger.Info($"{player.Data.PlayerName}:{location}", "RandomSpawn");
-                player.RpcSnapTo(location);
+                player.RpcSnapToForced(location);
             }
 
             public Vector2 GetLocation(Boolean first = false)

--- a/Roles/Impostor/Penguin.cs
+++ b/Roles/Impostor/Penguin.cs
@@ -238,14 +238,14 @@ class Penguin : RoleBase, IImpostor
                 var position = Player.transform.position;
                 if (Player.PlayerId != 0)
                 {
-                    AbductVictim.RpcSnapTo(position);
+                    AbductVictim.RpcSnapToForced(position);
                 }
                 else
                 {
                     _ = new LateTask(() =>
                     {
                         if (AbductVictim != null)
-                            AbductVictim.RpcSnapTo(position);
+                            AbductVictim.RpcSnapToForced(position);
                     }
                     , 0.25f, "");
                 }


### PR DESCRIPTION
ラグによってホスト-クライアント間でのSequenceIdの大小関係が狂い予期しない動作が起きる
強制テレポートのSequenceIdの増加幅を拡大